### PR TITLE
Add MoveItPy boilerplate

### DIFF
--- a/dependencies.repos
+++ b/dependencies.repos
@@ -43,6 +43,10 @@ repositories:
     type: git
     url: https://github.com/Tiago-Harmonic/tiago_moveit_config.git
     version: jazzy
+  tiago_moveitpy:
+    type: git
+    url: https://github.com/Tiago-Harmonic/tiago_moveitpy.git
+    version: main
   tiago_navigation:
     type: git
     url: https://github.com/Tiago-Harmonic/tiago_navigation


### PR DESCRIPTION
Following that conversation https://github.com/Tiago-Harmonic/tiago_harmonic/issues/13#issuecomment-2747828255 I am adding a boilerplate for using Tiago Harmonic with MoveItPy.

If you want to accept that MR:
1. Fork https://github.com/ymollard/tiago_moveitpy into the https://github.com/Tiago-Harmonic/ namespace
2. Accept that MR

Also note that this MR adds a dependency to MoveItPy, so you may want to fork the repo without accepting the MR modifying the dependencies.repos